### PR TITLE
feat: add option to limit concurrency

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -15,7 +15,7 @@ type untypedCircuit interface {
 
 // observer is used to observe the result of a single wrapped call through the circuit breaker.
 type observer interface {
-	// observe is called after the wrapped function returns. If [Circuit.Do] returns a non-nil [Observable], it will be
+	// observe is called after the wrapped function returns. If [Circuit.Do] returns a non-nil [observer], it will be
 	// called exactly once.
 	observe(failure bool)
 }

--- a/breaker.go
+++ b/breaker.go
@@ -7,12 +7,13 @@ import (
 	"time"
 )
 
-// untypedCircuit is used to avoid type annotations when implementing a breaker.
+// untypedCircuit is used to avoid type annotations when implementing breakers.
 type untypedCircuit interface {
 	stateForCall() State
 	setOpenedAt(int64)
 }
 
+// observer is used to observe the result of a single wrapped call through the circuit breaker.
 type observer interface {
 	// observe is called after the wrapped function returns. If [Circuit.Do] returns a non-nil [Observable], it will be
 	// called exactly once.

--- a/error.go
+++ b/error.go
@@ -11,4 +11,8 @@ func (b Error) Error() string {
 	return "hoglet: " + b.msg
 }
 
-var ErrCircuitOpen = Error{msg: "breaker is open"}
+var (
+	ErrCircuitOpen             = Error{msg: "breaker is open"}
+	ErrConcurrencyLimitReached = Error{msg: "concurrency limit reached"}
+	ErrWaitingForSlot          = Error{msg: "waiting for slot"}
+)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	golang.org/x/sync v0.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/hoglet.go
+++ b/hoglet.go
@@ -30,10 +30,13 @@ type options struct {
 	// limited (~1) amount of calls are allowed that - if successful - may re-close the breaker.
 	halfOpenDelay time.Duration
 
-	// observerForCall is a function that returns an observer for the next call.
 	// Usually, this is implemented by the breaker, but it can be overridden for testing purposes.
 	observerForCall observerFactory
 }
+
+// observerFactory is a function that returns one observer for each call going through the circuit.
+// It is used analogously to a http.Handler, allowing different plugins to "wrap" each execution.
+type observerFactory func(context.Context) (observer, error)
 
 // Breaker is the interface implemented by the different breakers, responsible for actually opening the circuit.
 // Each implementation behaves differently when deciding whether to open the breaker upon failure.
@@ -47,8 +50,6 @@ type Breaker interface {
 	// If the breaker is closed, it returns a non-nil [Observable] that will be used to observe the result of the call.
 	observerForCall(context.Context) (observer, error)
 }
-
-type observerFactory func(context.Context) (observer, error)
 
 // BreakableFunc is the type of the function wrapped by a Breaker.
 type BreakableFunc[IN, OUT any] func(context.Context, IN) (OUT, error)

--- a/hoglet.go
+++ b/hoglet.go
@@ -45,9 +45,9 @@ type Breaker interface {
 	connect(untypedCircuit)
 
 	// observerForCall returns an observer for the incoming call.
-	// It is called exactly once per call to [Breaker.Do], before calling the wrapped function.
+	// It is called exactly once per call to [Circuit.Call], before calling the wrapped function.
 	// If the breaker is open, it returns nil.
-	// If the breaker is closed, it returns a non-nil [Observable] that will be used to observe the result of the call.
+	// If the breaker is closed, it returns a non-nil [observer] that will be used to observe the result of the call.
 	observerForCall(context.Context) (observer, error)
 }
 
@@ -183,7 +183,7 @@ func (c *Circuit[IN, OUT]) Call(ctx context.Context, in IN) (out OUT, err error)
 var internalCancellation = errors.New("internal cancellation")
 
 // observeCtx observes the given context for cancellation and records it as a failure.
-// It assumes [Observable.Observe] is idempotent and deduplicates calls itself.
+// It assumes [observer] is idempotent and deduplicates calls itself.
 func (c *Circuit[IN, OUT]) observeCtx(obs observer, ctx context.Context) {
 	// We want to observe a context error as soon as possible to open the breaker, but at the same time we want to
 	// keep the call to the wrapped function synchronous to avoid all pitfalls that come with asynchronicity.

--- a/hoglet_test.go
+++ b/hoglet_test.go
@@ -83,11 +83,11 @@ type mockBreaker struct {
 }
 
 // observerForCall implements [Breaker]
-func (mt *mockBreaker) observerForCall() observer {
+func (mt *mockBreaker) observerForCall(context.Context) (observer, error) {
 	if mt.open {
-		return nil
+		return nil, ErrCircuitOpen
 	} else {
-		return &mockObservable{breaker: mt}
+		return &mockObservable{breaker: mt}, nil
 	}
 }
 
@@ -102,7 +102,9 @@ type mockObservable struct {
 // observe implements [Observer]
 func (mo *mockObservable) observe(failure bool) {
 	mo.once.Do(func() {
-		mo.breaker.open = failure
+		if mo.breaker != nil {
+			mo.breaker.open = failure
+		}
 	})
 }
 

--- a/hoglet_test.go
+++ b/hoglet_test.go
@@ -99,7 +99,7 @@ type mockObservable struct {
 	once    sync.Once
 }
 
-// observe implements [Observer]
+// observe implements [observer]
 func (mo *mockObservable) observe(failure bool) {
 	mo.once.Do(func() {
 		if mo.breaker != nil {

--- a/limiter.go
+++ b/limiter.go
@@ -16,8 +16,8 @@ func newLimiter(origFactory observerFactory, limit int64, block bool) observerFa
 			return nil, err
 		}
 		return observableCall(func(b bool) {
+			defer sem.Release(1)
 			o.observe(b)
-			sem.Release(1)
 		}), nil
 	}
 

--- a/limiter.go
+++ b/limiter.go
@@ -1,0 +1,39 @@
+package hoglet
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/semaphore"
+)
+
+func newLimiter(origFactory observerFactory, limit int64, block bool) observerFactory {
+	sem := semaphore.NewWeighted(limit)
+
+	wrappedFactory := func(ctx context.Context) (observer, error) {
+		o, err := origFactory(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return observableCall(func(b bool) {
+			o.observe(b)
+			sem.Release(1)
+		}), nil
+	}
+
+	if block {
+		return func(ctx context.Context) (observer, error) {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrWaitingForSlot, err)
+			}
+			return wrappedFactory(ctx)
+		}
+	}
+	return func(ctx context.Context) (observer, error) {
+		if sem.TryAcquire(1) {
+			return wrappedFactory(ctx)
+		} else {
+			return nil, ErrConcurrencyLimitReached
+		}
+	}
+}

--- a/limiter.go
+++ b/limiter.go
@@ -30,10 +30,9 @@ func newLimiter(origFactory observerFactory, limit int64, block bool) observerFa
 		}
 	}
 	return func(ctx context.Context) (observer, error) {
-		if sem.TryAcquire(1) {
-			return wrappedFactory(ctx)
-		} else {
+		if !sem.TryAcquire(1) {
 			return nil, ErrConcurrencyLimitReached
 		}
+		return wrappedFactory(ctx)
 	}
 }

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -7,11 +7,23 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+type mockPanickingObservable struct{}
+
+func (mo *mockPanickingObservable) observe(shouldPanic bool) {
+	// abuse the observer interface to signal a panic
+	if shouldPanic {
+		panic("mockObservable meant to panic")
+	}
+}
+
 func Test_newLimiter(t *testing.T) {
-	orig := func(context.Context) (observer, error) {
-		return &mockObservable{}, nil
+	orig := func() observerFactory {
+		return func(context.Context) (observer, error) {
+			return &mockPanickingObservable{}, nil
+		}
 	}
 
 	type args struct {
@@ -19,40 +31,100 @@ func Test_newLimiter(t *testing.T) {
 		block bool
 	}
 	tests := []struct {
-		name    string
-		args    args
-		calls   int
-		cancel  bool
-		wantErr error
+		name        string
+		args        args
+		calls       int
+		cancel      bool
+		wantPanicOn *int // which call to panic on (if at all)
+		wantErr     error
 	}{
-		{"under limit", args{limit: 1, block: false}, 0, false, nil},
-		{"over limit; non-blocking", args{limit: 1, block: false}, 2, false, ErrConcurrencyLimitReached},
-		{"over limit; blocking", args{limit: 1, block: true}, 2, false, ErrWaitingForSlot},
+		{
+			name:    "under limit",
+			args:    args{limit: 1, block: false},
+			calls:   0,
+			wantErr: nil,
+		},
+		{
+			name:    "over limit; non-blocking",
+			args:    args{limit: 1, block: false},
+			calls:   1,
+			wantErr: ErrConcurrencyLimitReached,
+		},
+		{
+			name:    "on limit; blocking",
+			args:    args{limit: 1, block: true},
+			calls:   1,
+			cancel:  true, // cancel simulates a timeout in this case
+			wantErr: ErrWaitingForSlot,
+		},
+		{
+			name:    "cancelation releases with error",
+			args:    args{limit: 1, block: true},
+			calls:   1,
+			cancel:  true,
+			wantErr: context.Canceled,
+		},
+		{
+			name:        "panic releases",
+			args:        args{limit: 1, block: true},
+			calls:       1,
+			cancel:      false,
+			wantPanicOn: ptr(0),
+			wantErr:     nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-			defer cancel()
+			ctxCalls, cancelCalls := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancelCalls()
 
-			wg := &sync.WaitGroup{}
+			wgStart := &sync.WaitGroup{}
+			wgStop := &sync.WaitGroup{}
+			defer wgStop.Wait()
 
-			of := newLimiter(orig, tt.args.limit, tt.args.block)
+			of := newLimiter(orig(), tt.args.limit, tt.args.block)
 			for i := 0; i < tt.calls; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					_, _ = of(ctx)
-				}()
+				wantPanic := tt.wantPanicOn != nil && *tt.wantPanicOn == i
+
+				f := func() {
+					defer wgStop.Done()
+					o, err := of(ctxCalls)
+					wgStart.Done()
+					require.NoError(t, err)
+
+					<-ctxCalls.Done()
+
+					o.observe(wantPanic)
+				}
+
+				wgStart.Add(1)
+				wgStop.Add(1)
+				if wantPanic {
+					go assert.Panics(t, f)
+				} else {
+					go f()
+				}
 			}
 
-			wg.Wait()
+			ctx, cancel := context.WithCancel(context.Background())
 
 			if tt.cancel {
 				cancel()
+			} else {
+				defer cancel()
 			}
 
-			_, err := of(ctx)
+			wgStart.Wait() // ensure all calls are started
+
+			o, err := of(ctx)
 			assert.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErr == nil {
+				assert.NotNil(t, o)
+			}
 		})
 	}
+}
+
+func ptr[T any](in T) *T {
+	return &in
 }

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -1,0 +1,58 @@
+package hoglet
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newLimiter(t *testing.T) {
+	orig := func(context.Context) (observer, error) {
+		return &mockObservable{}, nil
+	}
+
+	type args struct {
+		limit int64
+		block bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		calls   int
+		cancel  bool
+		wantErr error
+	}{
+		{"under limit", args{limit: 1, block: false}, 0, false, nil},
+		{"over limit; non-blocking", args{limit: 1, block: false}, 2, false, ErrConcurrencyLimitReached},
+		{"over limit; blocking", args{limit: 1, block: true}, 2, false, ErrWaitingForSlot},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			wg := &sync.WaitGroup{}
+
+			of := newLimiter(orig, tt.args.limit, tt.args.block)
+			for i := 0; i < tt.calls; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, _ = of(ctx)
+				}()
+			}
+
+			wg.Wait()
+
+			if tt.cancel {
+				cancel()
+			}
+
+			_, err := of(ctx)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/options.go
+++ b/options.go
@@ -37,3 +37,14 @@ func WithFailureCondition(condition func(error) bool) Option {
 func IgnoreContextCancelation(err error) bool {
 	return err != nil && err != context.Canceled
 }
+
+// WithConcurrencyLimit sets the maximum number of concurrent calls to the provided limit. If the limit is reached, the
+// circuit's behavior depends on the blocking parameter:
+//   - it either returns [ErrConcurrencyLimitReached] immediately if blocking is false
+//   - or blocks until a slot is available if blocking is true, potentially returning [ErrWaitingForSlot] if the context
+//     is canceled or times out while waiting.
+func WithConcurrencyLimit(limit int64, blocking bool) Option {
+	return optionFunc(func(b *options) {
+		b.observerForCall = newLimiter(b.observerForCall, limit, blocking)
+	})
+}


### PR DESCRIPTION
This adds an option to limit the circuit's concurrency:
```go
circuit := hoglet.NewCircuit(
        func(context.Context, any) (any, error) { return nil, nil },
        hoglet.NewEWMABreaker(10, 0.9),
        hoglet.WithConcurrencyLimit(100, false),
    )
```

The limit may be non-blocking (fail immediately) or blocking (holding off on calls over limit).

When blocking, context cancellation is respected to avoid requests piling up, but these do not count towards the failure rate. This means the circuit will not open just by having too many calls time out while waiting for a slot.