### PR TITLE
perf: avoid closures that cause allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.out
 
 /go.work*
+
+*.bench

--- a/hoglet_test.go
+++ b/hoglet_test.go
@@ -36,7 +36,8 @@ func BenchmarkHoglet_Do_EWMA(b *testing.B) {
 	h, err := NewCircuit(
 		func(context.Context, struct{}) (out struct{}, err error) { return },
 		NewEWMABreaker(10, 0.9),
-		WithBreakerMiddleware(ConcurrencyLimiter(1, true)),
+		WithHalfOpenDelay(time.Second),
+		// WithBreakerMiddleware(ConcurrencyLimiter(1, true)),
 	)
 	require.NoError(b, err)
 
@@ -56,7 +57,7 @@ func BenchmarkHoglet_Do_SlidingWindow(b *testing.B) {
 	h, err := NewCircuit(
 		func(context.Context, struct{}) (out struct{}, err error) { return },
 		NewSlidingWindowBreaker(10*time.Second, 0.9),
-		WithBreakerMiddleware(ConcurrencyLimiter(1, true)),
+		// WithBreakerMiddleware(ConcurrencyLimiter(1, true)),
 	)
 	require.NoError(b, err)
 


### PR DESCRIPTION
This is a light improvement on allocations and performance:

```
pkg: github.com/exaring/hoglet
cpu: 12th Gen Intel(R) Core(TM) i7-1250U
                           │  old.bench   │              new.bench              │
                           │    sec/op    │    sec/op     vs base               │
Hoglet_Do_EWMA-12            409.7n ± 12%   376.9n ± 17%       ~ (p=0.075 n=10)
Hoglet_Do_SlidingWindow-12   463.2n ±  2%   453.3n ±  7%       ~ (p=0.149 n=10)
geomean                      435.6n         413.4n        -5.10%

                           │ old.bench  │             new.bench              │
                           │    B/op    │    B/op     vs base                │
Hoglet_Do_EWMA-12            240.0 ± 0%   208.0 ± 0%  -13.33% (p=0.000 n=10)
Hoglet_Do_SlidingWindow-12   240.0 ± 0%   208.0 ± 0%  -13.33% (p=0.000 n=10)
geomean                      240.0        208.0       -13.33%

                           │ old.bench  │             new.bench              │
                           │ allocs/op  │ allocs/op   vs base                │
Hoglet_Do_EWMA-12            6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=10)
Hoglet_Do_SlidingWindow-12   6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=10)
geomean                      6.000        5.000       -16.67%

```

Still some work to do. We should be able to get to 1-2 allocs per call.
I do not think zero allocations are possible as long as we have the asynchronous reactions to context deadlines/cancelations, since that needs sharing across goroutines.