### PR TITLE
fix context cancelled check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ h, err := hoglet.NewCircuit(
         return Foo{}, fmt.Errorf("bar is not 42")
     },
     hoglet.NewSlidingWindowBreaker(10, 0.1),
-    hoglet.WithFailureCondition(hoglet.IgnoreContextCancelation),
+    hoglet.WithFailureCondition(hoglet.IgnoreContextCanceled),
 )
 /* if err != nil ... */
 
@@ -38,7 +38,7 @@ these observations according to their own logic, optionally opening the circuit.
 
 An open circuit does not allow any calls to go through, and will return an error immediately.
 
-If the wrapped function blocks, `Circuit.Call` will block as well, but any context cancelations or expirations will
+If the wrapped function blocks, `Circuit.Call` will block as well, but any context cancellations or expirations will
 count towards the failure rate, allowing the circuit to respond timely to failures, while still having well-defined and
 non-racy behavior around the failed function.
 

--- a/hoglet_test.go
+++ b/hoglet_test.go
@@ -99,7 +99,7 @@ func TestCircuit_ignored_context_cancellation_still_returned(t *testing.T) {
 			return "expected", ctx.Err()
 		},
 		nil,
-		WithFailureCondition(IgnoreContextCancelation))
+		WithFailureCondition(IgnoreContextCanceled))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -59,7 +59,7 @@ func Test_ConcurrencyLimiter(t *testing.T) {
 			wantErr: hoglet.ErrWaitingForSlot,
 		},
 		{
-			name:    "cancelation releases with error",
+			name:    "cancellation releases with error",
 			args:    args{limit: 1, block: true},
 			calls:   1,
 			cancel:  true,

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package hoglet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -38,9 +39,9 @@ func WithFailureCondition(condition func(error) bool) Option {
 	})
 }
 
-// IgnoreContextCancelation is a helper function for [WithFailureCondition] that ignores [context.Canceled] errors.
-func IgnoreContextCancelation(err error) bool {
-	return err != nil && err != context.Canceled
+// IgnoreContextCanceled is a helper function for [WithFailureCondition] that ignores [context.Canceled] errors.
+func IgnoreContextCanceled(err error) bool {
+	return err != nil && !errors.Is(err, context.Canceled)
 }
 
 // WithMiddleware allows wrapping the [Breaker] via a [BreakerMiddleware].


### PR DESCRIPTION
`IgnoreContextCancellation` would only work with bare errors and ignore wrapped ones. This should fix that.

Plus, we rename `IgnoreContextCancellation` to `IgnoreContextCanceled`: shorter and less ambiguous spelling :wink: 