### PR TITLE
fix(sliding window): implicitly set half-open delay

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -208,6 +208,19 @@ func (s *SlidingWindowBreaker) observe(halfOpen, failure bool) stateChange {
 	}
 }
 
+var _ Option = (*SlidingWindowBreaker)(nil)
+
+// apply implements Option.
+func (s *SlidingWindowBreaker) apply(o *options) error {
+	if o.halfOpenDelay == 0 || o.halfOpenDelay > s.windowSize {
+		o.halfOpenDelay = s.windowSize
+	}
+	return nil
+}
+
 func sinceMicros(micros int64) time.Duration {
+	if micros == 0 {
+		return 0
+	}
 	return time.Since(time.UnixMicro(micros))
 }

--- a/breaker.go
+++ b/breaker.go
@@ -1,6 +1,7 @@
 package hoglet
 
 import (
+	"fmt"
 	"math"
 	"sync/atomic"
 	"time"
@@ -123,6 +124,14 @@ func (e *EWMABreaker) observe(halfOpen, failure bool) stateChange {
 	}
 }
 
+// apply implements Option.
+func (e *EWMABreaker) apply(o *options) error {
+	if o.halfOpenDelay == 0 {
+		return fmt.Errorf("EWMABreaker requires a half-open delay")
+	}
+	return nil
+}
+
 // SlidingWindowBreaker is a [Breaker] that uses a sliding window to determine the error rate.
 type SlidingWindowBreaker struct {
 	windowSize time.Duration
@@ -207,8 +216,6 @@ func (s *SlidingWindowBreaker) observe(halfOpen, failure bool) stateChange {
 		return stateChangeClose
 	}
 }
-
-var _ Option = (*SlidingWindowBreaker)(nil)
 
 // apply implements Option.
 func (s *SlidingWindowBreaker) apply(o *options) error {

--- a/hoglet.go
+++ b/hoglet.go
@@ -98,6 +98,12 @@ func NewCircuit[IN, OUT any](f WrappedFunc[IN, OUT], breaker Breaker, opts ...Op
 		}
 	}
 
+	if breakerOpt, ok := breaker.(Option); ok {
+		if err := breakerOpt.apply(&o); err != nil {
+			return nil, fmt.Errorf("applying breaker option: %w", err)
+		}
+	}
+
 	c.options = o
 
 	if _, ok := breaker.(*EWMABreaker); ok && c.halfOpenDelay == 0 {

--- a/hoglet_test.go
+++ b/hoglet_test.go
@@ -122,6 +122,10 @@ func (mt *mockBreaker) observe(halfOpen, failure bool) stateChange {
 	return stateChangeClose
 }
 
+func (mt *mockBreaker) apply(o *options) error {
+	return nil
+}
+
 func TestHoglet_Do(t *testing.T) {
 	type calls struct {
 		arg       noopIn


### PR DESCRIPTION
A previous refactoring of the circuit+breaker meant a sliding window circuit without explicit half-open would never leave the open state, unlike the docs indicated.

This PR also fixes an unrelated bug: the prometheus extension was not accounting for dropped calls.