### PR TITLE
feat!: turn prometheus middleware into collector

### DIFF
--- a/hoglet.go
+++ b/hoglet.go
@@ -53,8 +53,16 @@ type ObserverFactory interface {
 	ObserverForCall(context.Context, State) (Observer, error)
 }
 
-// BreakerMiddleware is a function that wraps an [ObserverFactory] and returns a new [ObserverFactory].
-type BreakerMiddleware func(ObserverFactory) (ObserverFactory, error)
+// BreakerMiddleware wraps an [ObserverFactory] and returns a new [ObserverFactory].
+type BreakerMiddleware interface {
+	Wrap(ObserverFactory) (ObserverFactory, error)
+}
+
+type BreakerMiddlewareFunc func(ObserverFactory) (ObserverFactory, error)
+
+func (f BreakerMiddlewareFunc) Wrap(of ObserverFactory) (ObserverFactory, error) {
+	return f(of)
+}
 
 // WrappedFunc is the type of the function wrapped by a Breaker.
 type WrappedFunc[IN, OUT any] func(context.Context, IN) (OUT, error)

--- a/limiter.go
+++ b/limiter.go
@@ -13,7 +13,7 @@ import (
 //   - or blocks until a slot is available if blocking is true, potentially returning [ErrWaitingForSlot]. The returned
 //     error wraps the underlying cause (e.g. [context.Canceled] or [context.DeadlineExceeded]).
 func ConcurrencyLimiter(limit int64, block bool) BreakerMiddleware {
-	return func(next ObserverFactory) (ObserverFactory, error) {
+	return BreakerMiddlewareFunc(func(next ObserverFactory) (ObserverFactory, error) {
 		cl := concurrencyLimiter{
 			sem:  semaphore.NewWeighted(limit),
 			next: next,
@@ -26,7 +26,7 @@ func ConcurrencyLimiter(limit int64, block bool) BreakerMiddleware {
 		return concurrencyLimiterNonBlocking{
 			concurrencyLimiter: cl,
 		}, nil
-	}
+	})
 }
 
 type concurrencyLimiter struct {

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -84,7 +84,7 @@ func Test_ConcurrencyLimiter(t *testing.T) {
 			defer wgStop.Wait()
 
 			cl := hoglet.ConcurrencyLimiter(tt.args.limit, tt.args.block)
-			of, err := cl(mockObserverFactory{})
+			of, err := cl.Wrap(mockObserverFactory{})
 			require.NoError(t, err)
 			for i := 0; i < tt.calls; i++ {
 				wantPanic := tt.wantPanicOn != nil && *tt.wantPanicOn == i

--- a/options.go
+++ b/options.go
@@ -52,7 +52,7 @@ func IgnoreContextCanceled(err error) bool {
 // middleware and should therefore be AFTER it in the parameter list.
 func WithBreakerMiddleware(bm BreakerMiddleware) Option {
 	return optionFunc(func(o *options) error {
-		b, err := bm(o.observerFactory)
+		b, err := bm.Wrap(o.observerFactory)
 		if err != nil {
 			return fmt.Errorf("creating middleware: %w", err)
 		}


### PR DESCRIPTION
This makes integration with the "recursive collectors" pattern easier, since no additional registerer is necessary.
Users who already have a prometheus.Registerer in scope can explicitly register the middleware.

BREAKING CHANGE: all prometheus usage must be refactored