### PR TITLE
perf: skip watchdog goroutine and dedup for uncancellable contexts

### DIFF
--- a/hoglet.go
+++ b/hoglet.go
@@ -243,14 +243,25 @@ func Wrap[IN, OUT any](c *Circuit, f WrappableFunc[IN, OUT]) WrappableFunc[IN, O
 			return out, err
 		}
 
-		// ensure we dedup the final - potentially wrapped - observer.
-		obs = dedupObservableCall(obs)
+		// The watchdog goroutine exists to record a context cancellation/deadline as a failure promptly, even if the
+		// wrapped function ignores its context and blocks. If the context can never be canceled (no deadline and no
+		// cancellation, e.g. [context.Background]), the watchdog can never fire usefully, so we skip it and the
+		// associated context allocation entirely, relying solely on the deferred observation below.
+		//
+		// TODO: allow skipping the watchdog via an option for callers that guarantee their wrapped function respects
+		// its context, trading prompt cancellation detection for one less goroutine + context allocation per call.
+		if ctx.Done() != nil {
+			// Only here can the watchdog race the deferred observe, so dedup to ensure the - potentially wrapped -
+			// observer is observed exactly once. Without a watchdog the deferred func below is the sole observer
+			// (normal return and panic go through the same defer and are mutually exclusive), so no dedup is needed.
+			// This relies on breaker middleware observing synchronously; an async middleware observer must dedup itself.
+			obs = dedupObservableCall(obs)
 
-		obsCtx, cancel := context.WithCancelCause(ctx)
-		defer cancel(errWrappedFunctionDone)
+			obsCtx, cancel := context.WithCancelCause(ctx)
+			defer cancel(errWrappedFunctionDone)
 
-		// TODO: we could skip this if we could ensure the original context has neither cancellation nor deadline
-		go c.observeCtx(obs, obsCtx)
+			go c.observeCtx(obs, obsCtx)
+		}
 
 		defer func() {
 			// ensure we also open the breaker on panics


### PR DESCRIPTION
## What

On the uncancellable-context fast path, skip the per-call watchdog goroutine, its `context.WithCancelCause` allocation, and the observer dedup wrapper.

## Why

Every call paid: a goroutine + a context allocation (watchdog) and a second allocation (dedup wrapper). The watchdog only serves to record a context cancellation/deadline promptly — when `ctx.Done() == nil` (e.g. `context.Background()`) it can never fire usefully. And with no watchdog there is no second observer racing the deferred observe, so the dedup is redundant too.

## How

- `if ctx.Done() != nil { ... }` gates the watchdog goroutine + context allocation.
- The `dedupObservableCall` wrapper moves inside that branch (normal return and panic share one defer, so they're mutually exclusive — single observer).

## Results

`benchstat` of `BenchmarkHoglet_Do_*` (which call through `context.Background()`, the uncancellable fast path), `main` vs this branch, `-count=10` on an AMD Ryzen AI 9 HX 370:

```
goos: linux
goarch: amd64
pkg: github.com/exaring/hoglet
cpu: AMD Ryzen AI 9 HX 370 w/ Radeon 890M
                           │   old.txt   │               new.txt               │
                           │   sec/op    │   sec/op     vs base                │
Hoglet_Do_EWMA-24            563.0n ± 1%   140.3n ± 5%  -75.08% (p=0.000 n=10)
Hoglet_Do_SlidingWindow-24   563.8n ± 1%   115.1n ± 1%  -79.58% (p=0.000 n=10)
geomean                      563.3n        127.1n       -77.44%

                           │   old.txt   │              new.txt               │
                           │    B/op     │    B/op     vs base                │
Hoglet_Do_EWMA-24            192.00 ± 2%   16.00 ± 0%  -91.67% (p=0.000 n=10)
Hoglet_Do_SlidingWindow-24   192.00 ± 0%   16.00 ± 0%  -91.67% (p=0.000 n=10)
geomean                       192.0        16.00       -91.67%

                           │  old.txt   │              new.txt               │
                           │ allocs/op  │ allocs/op   vs base                │
Hoglet_Do_EWMA-24            5.000 ± 0%   1.000 ± 0%  -80.00% (p=0.000 n=10)
Hoglet_Do_SlidingWindow-24   5.000 ± 0%   1.000 ± 0%  -80.00% (p=0.000 n=10)
geomean                      5.000        1.000       -80.00%
```

Latency drops ~75–80%, allocations 5 → 1/op, bytes 192 → 16 B/op — plus one fewer goroutine per call. Cancellable/deadline-context callers take the unchanged path and are unaffected.

## Notes

Relies on breaker middleware observing synchronously (documented inline); an async middleware observer must dedup itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
