### PR TITLE
perf: avoid hot-path atomic write when circuit state is unchanged

### DIFF
--- a/hoglet.go
+++ b/hoglet.go
@@ -150,6 +150,12 @@ func (c *Circuit) stateForCall() State {
 // open marks the circuit as open, if it not already.
 // It is safe for concurrent calls and only the first one will actually set opening time.
 func (c *Circuit) open() {
+	// Only attempt to open if currently closed. This avoids the CAS/RMW when the breaker signals open while
+	// openedAt is already non-zero (e.g., repeated open signals during half-open/concurrent transitions).
+	if c.openedAt.Load() != 0 {
+		return // noop
+	}
+
 	// CompareAndSwap is needed to avoid clobbering another goroutine's openedAt value.
 	c.openedAt.CompareAndSwap(0, time.Now().UnixMicro())
 }
@@ -161,6 +167,10 @@ func (c *Circuit) reopen() {
 
 // close closes the circuit.
 func (c *Circuit) close() {
+	// Likewise, only clear if currently open, so a healthy closed circuit stays read-only on the hot path.
+	if c.openedAt.Load() == 0 {
+		return // noop
+	}
 	c.openedAt.Store(0)
 }
 


### PR DESCRIPTION
## What

Guard the `openedAt` mutation in `stateObserver.Observe` with a `Load` so a steady-state circuit doesn't write to shared state on every call.

## Why

`SlidingWindowBreaker.observe` returns `stateChangeClose` on every below-threshold call, so a healthy closed circuit ran `openedAt.Store(0)` on **every** call — an unconditional atomic write to a cache line that's already `0`. Under concurrency that bounces the line between cores (MESI invalidation), reintroducing exactly the cross-core contention the lock-free design exists to avoid — for a write that changes nothing.

## How

- `stateChangeOpen` → only `open()` if `openedAt.Load() == 0`.
- `stateChangeClose` → only `close()` if `openedAt.Load() != 0`.

A `Load` keeps the cache line shared across cores; the steady-state happy path becomes read-only.

## Results

Micro-benchmarks isolating `open()`/`close()` on an unchanged circuit show a large win (the `Load` keeps the line shared instead of forcing exclusive ownership per call; the serial `open()` win is mostly from skipping `time.Now()`). The end-to-end `Do` path shows **no measurable change** — at ~565 ns/op it is dominated by the per-call goroutine and 5 allocations, so the ~10–25 ns saved is below the noise floor. This is contention hygiene, not a throughput improvement.

benchstat, 10 runs, AMD Ryzen AI 9 HX 370 (24 threads); `Circuit_*` are throwaway micro-benchmarks calling `open()`/`close()` directly:

```
                                        │   old.bench    │               new.bench                │
                                        │     sec/op     │     sec/op      vs base                │
Hoglet_Do_EWMA-24                            565.5n ± 2%     574.0n ±  2%        ~ (p=0.363 n=10)
Hoglet_Do_SlidingWindow-24                   564.8n ± 1%     567.8n ±  3%        ~ (p=0.218 n=10)
Circuit_close_alreadyClosed_parallel-24   22.74000n ± 4%   0.05736n ±  6%  -99.75% (p=0.000 n=10)
Circuit_close_alreadyClosed_serial-24      10.0450n ± 2%    0.5050n ±  6%  -94.97% (p=0.000 n=10)
Circuit_open_alreadyOpen_parallel-24       28.2650n ± 1%    0.2400n ±  5%  -99.15% (p=0.000 n=10)
Circuit_open_alreadyOpen_serial-24         102.500n ± 2%     2.502n ± 22%  -97.56% (p=0.000 n=10)
```

B/op and allocs/op are unchanged. (An earlier version of this description claimed −31…−43% on the end-to-end benchmarks; that did not reproduce.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
