### PR TITLE
chore(actions): update steps to v7

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,8 +8,8 @@ jobs:
         go: [ '1.25', '1.24' ]
     name: go ${{ matrix.go }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go }}
       - run: go list -m | xargs go test -race -v


### PR DESCRIPTION
Annotations had [some warnings](https://github.com/exaring/hoglet/actions/runs/30018968547).

This should fix it. I haven't seen any breaking changes which should affect us.